### PR TITLE
initialization of immutable objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -114,6 +115,13 @@
             <artifactId>spring-context</artifactId>
             <version>4.1.2.RELEASE</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>2.1</version>
+        </dependency>
+
 
         <!--
             Test dependencies

--- a/src/main/java/io/github/benas/jpopulator/impl/PopulatorImpl.java
+++ b/src/main/java/io/github/benas/jpopulator/impl/PopulatorImpl.java
@@ -28,8 +28,9 @@ import io.github.benas.jpopulator.api.Exclude;
 import io.github.benas.jpopulator.api.Populator;
 import io.github.benas.jpopulator.api.Randomizer;
 import org.apache.commons.math3.random.RandomDataGenerator;
-import org.springframework.objenesis.Objenesis;
-import org.springframework.objenesis.ObjenesisStd;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;

--- a/src/test/java/io/github/benas/jpopulator/beans/ImmutableBean.java
+++ b/src/test/java/io/github/benas/jpopulator/beans/ImmutableBean.java
@@ -1,0 +1,25 @@
+package io.github.benas.jpopulator.beans;
+
+import java.util.List;
+
+/**
+ * @author Dominik Frankowski (frankowski_d@poczta.onet.pl)
+ */
+public class ImmutableBean {
+    private final String finalValue;
+
+    private final List<String> finalCollection;
+
+    public ImmutableBean(String finalValue, List<String> finalCollection) {
+        this.finalValue = finalValue;
+        this.finalCollection = finalCollection;
+    }
+
+    public String getFinalValue() {
+        return finalValue;
+    }
+
+    public List<String> getFinalCollection() {
+        return finalCollection;
+    }
+}

--- a/src/test/java/io/github/benas/jpopulator/impl/PopulatorImplTest.java
+++ b/src/test/java/io/github/benas/jpopulator/impl/PopulatorImplTest.java
@@ -73,11 +73,11 @@ public class PopulatorImplTest {
     }
 
     @Test
-    public void finalFieldsShouldNotBePopulated() throws Exception {
+    public void finalFieldsShouldBePopulated() throws Exception {
         Person person = populator.populateBean(Person.class);
 
         assertThat(person).isNotNull();
-        assertThat(person.getId()).isNull();
+        assertThat(person.getId()).isNotNull();
     }
 
     @Test
@@ -286,5 +286,13 @@ public class PopulatorImplTest {
 
         assertThat(collectionsBean.getNavigableMap()).isNotNull();
         assertThat(collectionsBean.getNavigableMap()).isEmpty();
+    }
+
+    @Test
+    public void testImmutableBeanPopulation() throws Exception {
+        final ImmutableBean immutableBean = populator.populateBean(ImmutableBean.class);
+        assertThat(immutableBean).isNotNull();
+        assertThat(immutableBean.getFinalValue()).isNotNull();
+        assertThat(immutableBean.getFinalCollection()).isNotNull();
     }
 }


### PR DESCRIPTION
1. Currently it is not possible to create objects if default constructor does not exist or is not public.
Situation where default constructor does not exist is common when implementing immutable classes.

2. When we have immutable object, there is no settes for object. This also cause that we are unable to create object(PropertyUtils throws exceptions as it uses setters)


To solve#1 - I'm using Objenesis which is able to create object even if public constructor is not available

To solve#1 - I'm using reflection, but befoer doing it I'm ensuring that field is accessible (public). After setting I'm restoring previous state