### PR TITLE
Modifications necessary to compile against Java8, fixes javadoc errors.

### DIFF
--- a/jpopulator-core/pom.xml
+++ b/jpopulator-core/pom.xml
@@ -38,6 +38,11 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.github.benas</groupId>

--- a/jpopulator-core/src/main/java/io/github/benas/jpopulator/impl/PopulatorContext.java
+++ b/jpopulator-core/src/main/java/io/github/benas/jpopulator/impl/PopulatorContext.java
@@ -30,7 +30,7 @@ import java.util.Stack;
 
 /**
  * Context object for a single call on {@link io.github.benas.jpopulator.api.Populator}.
- * <p/>
+ * <p>
  * It contains a map of populated beans to avoid infinite recursion, and a stack of {@link ContextStackItem}.
  *
  * @author Rémi Alvergnat (toilal.dev@gmail.com)


### PR DESCRIPTION
The javadoc compiler in Java 8 is more strict than previous versions.  This change fixes the javadoc errors so that the project can build built with Java 8.